### PR TITLE
Fixed "minute - minutes" typo in last examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Implement a console-based social networking application (similar to Twitter) sat
 > \> Charlie follows Bob    
 > \> Charlie wall    
 > \> Charlie - I'm in New York today! Anyone wants to have a coffee? (15 seconds ago)     
-> \> Bob - Good game though. (1 minutes ago)     
-> \> Bob - Damn! We lost! (2 minute ago)     
+> \> Bob - Good game though. (1 minute ago)     
+> \> Bob - Damn! We lost! (2 minutes ago)     
 > \> Alice - I love the weather today (5 minutes ago)    
 
 ### General requirements 


### PR DESCRIPTION
Trying this kata (https://github.com/danielemegna/JavaSocialNetworkKata), I found a typo into the examples.
It jumped out running my AT :-)
